### PR TITLE
GitLab RunnerのWindowsのデフォルトシェルがPowershellとなったことへの対応

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,12 +6,14 @@ TexCompile:
   tags:
     - Windows
   script:
-    - set TexCompiler="lualatex"
-    - set SRC=thesis
-    - '%TexCompiler% %SRC%.tex'
-    - upbibtex %SRC%.aux
-    - '%TexCompiler% %SRC%.tex'
-    - '%TexCompiler% %SRC%.tex'
+    - $TexCompiler = "lualatex"
+    - $SRC = "thesis"
+    - $TexCompile = "$TexCompiler ${SRC}.tex"
+    - $BibCompile = "upbibtex ${SRC}.aux"
+    - Invoke-Expression $TexCompile
+    - Invoke-Expression $BibCompile
+    - Invoke-Expression $TexCompile
+    - Invoke-Expression $TexCompile
   artifacts:
     paths:
       - ./thesis.pdf


### PR DESCRIPTION
GitLab Runner のバージョン12.0以降はWindowsのデフォルトshellがpowershellとなった（参考：[Shells supported by GitLab Runner](https://docs.gitlab.com/runner/shells/)  
そのため，GitLab Runnerの自動コンパイル用スクリプトをCommand Prompt用からPowerShell用に変更した